### PR TITLE
fix function patchMissingTypes

### DIFF
--- a/src/collectTypeDefs.ts
+++ b/src/collectTypeDefs.ts
@@ -51,8 +51,9 @@ class TypeDefsCollector {
     definitionsAst: DocumentNode,
     schemaAst: DocumentNode,
   ) {
+    const objectTypeDefinitions = schemaAst.definitions.filter(o => o.kind == 'ObjectTypeDefinition');
     const schemaMap: DefinitionMap = _.keyBy(
-      schemaAst.definitions,
+      objectTypeDefinitions,
       (d: any) => d.name.value as string,
     )
     definitionsAst.definitions.forEach(def =>


### PR DESCRIPTION
If we use a schema generated with graphql-modules, it contains an additional node SchemaDefinition. Due this node is not a type definition, this PR filters it in the patchMissingTypes function